### PR TITLE
Elec 20  filtering by vote status

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Chrome",
+      "request": "launch",
+      "type": "pwa-chrome",
+      "url": "http://localhost:4200",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -22201,7 +22201,7 @@
           },
           {
             "name": "referendum_votes_aggregate",
-            "description": "fetch aggregated fields from the table: \"referendum_votes\"",
+            "description": "An aggregate relationship",
             "args": [
               {
                 "name": "distinct_on",
@@ -22769,7 +22769,7 @@
           },
           {
             "name": "settlements",
-            "description": "fetch data from the table: \"settlements\"",
+            "description": "An array relationship",
             "args": [
               {
                 "name": "distinct_on",
@@ -25505,6 +25505,22 @@
             "deprecationReason": null
           },
           {
+            "name": "referendum",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "referendums",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "referendumId",
             "description": null,
             "args": [],
@@ -25623,7 +25639,7 @@
           },
           {
             "name": "referendum_votes_aggregate",
-            "description": "fetch aggregated fields from the table: \"referendum_votes\"",
+            "description": "An aggregate relationship",
             "args": [
               {
                 "name": "distinct_on",
@@ -26318,6 +26334,18 @@
             "deprecationReason": null
           },
           {
+            "name": "referendum",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "referendums_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "referendumId",
             "description": null,
             "type": {
@@ -26446,6 +26474,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "referendum",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "referendums_obj_rel_insert_input",
               "ofType": null
             },
             "defaultValue": null,
@@ -26830,6 +26870,45 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "referendum_questions_obj_rel_insert_input",
+        "description": "input type for inserting object relation for remote table \"referendum_questions\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "data",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "referendum_questions_insert_input",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_conflict",
+            "description": "on conflict condition",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "referendum_questions_on_conflict",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "referendum_questions_on_conflict",
         "description": "on conflict condition type for table \"referendum_questions\"",
         "fields": null,
@@ -26927,6 +27006,18 @@
             "type": {
               "kind": "ENUM",
               "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "referendum",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "referendums_order_by",
               "ofType": null
             },
             "defaultValue": null,
@@ -27710,6 +27801,22 @@
             "deprecationReason": null
           },
           {
+            "name": "referendum_question",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "referendum_questions",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sectionId",
             "description": null,
             "args": [],
@@ -28397,6 +28504,18 @@
             "deprecationReason": null
           },
           {
+            "name": "referendum_question",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "referendum_questions_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "sectionId",
             "description": null,
             "type": {
@@ -28561,6 +28680,18 @@
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "referendum_question",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "referendum_questions_obj_rel_insert_input",
               "ofType": null
             },
             "defaultValue": null,
@@ -29054,6 +29185,18 @@
             "type": {
               "kind": "ENUM",
               "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "referendum_question",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "referendum_questions_order_by",
               "ofType": null
             },
             "defaultValue": null,
@@ -31489,6 +31632,45 @@
       },
       {
         "kind": "INPUT_OBJECT",
+        "name": "referendums_obj_rel_insert_input",
+        "description": "input type for inserting object relation for remote table \"referendums\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "data",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "referendums_insert_input",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_conflict",
+            "description": "on conflict condition",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "referendums_on_conflict",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
         "name": "referendums_on_conflict",
         "description": "on conflict condition type for table \"referendums\"",
         "fields": null,
@@ -33142,7 +33324,7 @@
           },
           {
             "name": "settlements",
-            "description": "fetch data from the table: \"settlements\"",
+            "description": "An array relationship",
             "args": [
               {
                 "name": "distinct_on",
@@ -37925,7 +38107,7 @@
           },
           {
             "name": "referendum_votes_aggregate",
-            "description": "fetch aggregated fields from the table: \"referendum_votes\"",
+            "description": "An aggregate relationship",
             "args": [
               {
                 "name": "distinct_on",
@@ -38493,7 +38675,7 @@
           },
           {
             "name": "settlements",
-            "description": "fetch data from the table: \"settlements\"",
+            "description": "An array relationship",
             "args": [
               {
                 "name": "distinct_on",
@@ -40518,6 +40700,200 @@
             "deprecationReason": null
           },
           {
+            "name": "referendum_votes",
+            "description": "fetch data from the table: \"referendum_votes\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "referendum_votes_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "referendum_votes_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "referendum_votes_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "referendum_votes",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "referendum_votes_aggregate",
+            "description": "An aggregate relationship",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "referendum_votes_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "referendum_votes_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "referendum_votes_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "referendum_votes_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "role",
             "description": null,
             "args": [],
@@ -40622,12 +40998,218 @@
             "deprecationReason": null
           },
           {
+            "name": "votes",
+            "description": "fetch data from the table: \"votes\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "votes_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "votes_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "votes_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "votes",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "votes_aggregate",
+            "description": "fetch aggregated fields from the table: \"votes\"",
+            "args": [
+              {
+                "name": "distinct_on",
+                "description": "distinct select on columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "votes_select_column",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "limit",
+                "description": "limit the number of rows returned",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "offset",
+                "description": "skip the first n rows. Use only with order_by",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "order_by",
+                "description": "sort the rows by one or more columns",
+                "type": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "votes_order_by",
+                      "ofType": null
+                    }
+                  }
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "where",
+                "description": "filter the rows returned",
+                "type": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "votes_bool_exp",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "votes_aggregate",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "votingSectionId",
             "description": null,
             "args": [],
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "voting_section",
+            "description": "An object relationship",
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "voting_section",
               "ofType": null
             },
             "isDeprecated": false,
@@ -41104,6 +41686,18 @@
             "deprecationReason": null
           },
           {
+            "name": "referendum_votes",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "referendum_votes_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "role",
             "description": null,
             "type": {
@@ -41188,11 +41782,35 @@
             "deprecationReason": null
           },
           {
+            "name": "votes",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_bool_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "votingSectionId",
             "description": null,
             "type": {
               "kind": "INPUT_OBJECT",
               "name": "Int_comparison_exp",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "voting_section",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "voting_section_bool_exp",
               "ofType": null
             },
             "defaultValue": null,
@@ -41413,6 +42031,18 @@
             "deprecationReason": null
           },
           {
+            "name": "referendum_votes",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "referendum_votes_arr_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "role",
             "description": null,
             "type": {
@@ -41497,11 +42127,35 @@
             "deprecationReason": null
           },
           {
+            "name": "votes",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_arr_rel_insert_input",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "votingSectionId",
             "description": null,
             "type": {
               "kind": "SCALAR",
               "name": "Int",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "voting_section",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "voting_section_obj_rel_insert_input",
               "ofType": null
             },
             "defaultValue": null,
@@ -42076,6 +42730,18 @@
             "deprecationReason": null
           },
           {
+            "name": "referendum_votes_aggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "referendum_votes_aggregate_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "role",
             "description": null,
             "type": {
@@ -42160,11 +42826,35 @@
             "deprecationReason": null
           },
           {
+            "name": "votes_aggregate",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_aggregate_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "votingSectionId",
             "description": null,
             "type": {
               "kind": "ENUM",
               "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "voting_section",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "voting_section_order_by",
               "ofType": null
             },
             "defaultValue": null,
@@ -43292,6 +43982,196 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "votes_aggregate_order_by",
+        "description": "order by aggregate values of table \"votes\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "avg",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_avg_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "count",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "max",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_max_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "min",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_min_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_stddev_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_pop",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_stddev_pop_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "stddev_samp",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_stddev_samp_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sum",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_sum_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_pop",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_var_pop_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "var_samp",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_var_samp_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "variance",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_variance_order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "votes_arr_rel_insert_input",
+        "description": "input type for inserting array relation for remote table \"votes\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "data",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "votes_insert_input",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_conflict",
+            "description": "on conflict condition",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "votes_on_conflict",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "votes_avg_fields",
         "description": "aggregate avg on columns",
@@ -43347,6 +44227,65 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "votes_avg_order_by",
+        "description": "order by avg() on columns of table \"votes\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sectionId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "votingId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -43764,6 +44703,101 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "votes_max_order_by",
+        "description": "order by max() on columns of table \"votes\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "createdAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eVote",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sectionId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vote",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "votingId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "votes_min_fields",
         "description": "aggregate min on columns",
@@ -43855,6 +44889,101 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "votes_min_order_by",
+        "description": "order by min() on columns of table \"votes\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "createdAt",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "eVote",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sectionId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "vote",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "votingId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -44302,6 +45431,65 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "votes_stddev_order_by",
+        "description": "order by stddev() on columns of table \"votes\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sectionId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "votingId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "votes_stddev_pop_fields",
         "description": "aggregate stddev_pop on columns",
@@ -44357,6 +45545,65 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "votes_stddev_pop_order_by",
+        "description": "order by stddev_pop() on columns of table \"votes\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sectionId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "votingId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -44420,6 +45667,65 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "votes_stddev_samp_order_by",
+        "description": "order by stddev_samp() on columns of table \"votes\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sectionId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "votingId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "votes_sum_fields",
         "description": "aggregate sum on columns",
@@ -44475,6 +45781,65 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "votes_sum_order_by",
+        "description": "order by sum() on columns of table \"votes\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sectionId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "votingId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -44591,6 +45956,65 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "votes_var_pop_order_by",
+        "description": "order by var_pop() on columns of table \"votes\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sectionId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "votingId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "votes_var_samp_fields",
         "description": "aggregate var_samp on columns",
@@ -44650,6 +46074,65 @@
         "possibleTypes": null
       },
       {
+        "kind": "INPUT_OBJECT",
+        "name": "votes_var_samp_order_by",
+        "description": "order by var_samp() on columns of table \"votes\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sectionId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "votingId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
         "kind": "OBJECT",
         "name": "votes_variance_fields",
         "description": "aggregate variance on columns",
@@ -44705,6 +46188,65 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "votes_variance_order_by",
+        "description": "order by variance() on columns of table \"votes\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "sectionId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "userId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "votingId",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "order_by",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },
@@ -45585,6 +47127,45 @@
         ],
         "inputFields": null,
         "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "voting_section_obj_rel_insert_input",
+        "description": "input type for inserting object relation for remote table \"voting_section\"",
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "data",
+            "description": null,
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "INPUT_OBJECT",
+                "name": "voting_section_insert_input",
+                "ofType": null
+              }
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "on_conflict",
+            "description": "on conflict condition",
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "voting_section_on_conflict",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
         "enumValues": null,
         "possibleTypes": null
       },

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -40584,22 +40584,6 @@
             "deprecationReason": null
           },
           {
-            "name": "eVoted",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "egn",
             "description": null,
             "args": [],
@@ -40975,22 +40959,6 @@
               "ofType": {
                 "kind": "SCALAR",
                 "name": "timestamptz",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "voted",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "SCALAR",
-                "name": "Boolean",
                 "ofType": null
               }
             },
@@ -41590,18 +41558,6 @@
             "deprecationReason": null
           },
           {
-            "name": "eVoted",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "Boolean_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "egn",
             "description": null,
             "type": {
@@ -41770,18 +41726,6 @@
             "deprecationReason": null
           },
           {
-            "name": "voted",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "Boolean_comparison_exp",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "votes",
             "description": null,
             "type": {
@@ -41928,18 +41872,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "eVoted",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -42108,18 +42040,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "voted",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -42634,18 +42554,6 @@
             "deprecationReason": null
           },
           {
-            "name": "eVoted",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "egn",
             "description": null,
             "type": {
@@ -42814,18 +42722,6 @@
             "deprecationReason": null
           },
           {
-            "name": "voted",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "order_by",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "votes_aggregate",
             "description": null,
             "type": {
@@ -42914,12 +42810,6 @@
             "deprecationReason": null
           },
           {
-            "name": "eVoted",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "egn",
             "description": "column name",
             "isDeprecated": false,
@@ -42981,12 +42871,6 @@
           },
           {
             "name": "updatedAt",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "voted",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null
@@ -43031,18 +42915,6 @@
             "deprecationReason": null
           },
           {
-            "name": "eVoted",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "egn",
             "description": null,
             "type": {
@@ -43168,18 +43040,6 @@
             "type": {
               "kind": "SCALAR",
               "name": "timestamptz",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "voted",
-            "description": null,
-            "type": {
-              "kind": "SCALAR",
-              "name": "Boolean",
               "ofType": null
             },
             "defaultValue": null,
@@ -43412,12 +43272,6 @@
             "deprecationReason": null
           },
           {
-            "name": "eVoted",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
             "name": "egn",
             "description": "column name",
             "isDeprecated": false,
@@ -43479,12 +43333,6 @@
           },
           {
             "name": "updatedAt",
-            "description": "column name",
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "voted",
             "description": "column name",
             "isDeprecated": false,
             "deprecationReason": null

--- a/metadata/databases/default/tables/public_referendum_questions.yaml
+++ b/metadata/databases/default/tables/public_referendum_questions.yaml
@@ -1,6 +1,10 @@
 table:
   name: referendum_questions
   schema: public
+object_relationships:
+- name: referendum
+  using:
+    foreign_key_constraint_on: referendumId
 array_relationships:
 - name: referendum_votes
   using:

--- a/metadata/databases/default/tables/public_referendum_votes.yaml
+++ b/metadata/databases/default/tables/public_referendum_votes.yaml
@@ -1,6 +1,10 @@
 table:
   name: referendum_votes
   schema: public
+object_relationships:
+- name: referendum_question
+  using:
+    foreign_key_constraint_on: questionId
 insert_permissions:
 - permission:
     backend_only: false
@@ -11,3 +15,32 @@ insert_permissions:
     - userId
     - vote
   role: user
+select_permissions:
+- permission:
+    columns:
+    - eVote
+    - questionId
+    - vote
+    filter: {}
+  role: central
+- permission:
+    columns:
+    - eVote
+    - questionId
+    - vote
+    filter: {}
+  role: centralLeader
+- permission:
+    columns:
+    - eVote
+    - questionId
+    - vote
+    filter: {}
+  role: section
+- permission:
+    columns:
+    - eVote
+    - questionId
+    - vote
+    filter: {}
+  role: sectionLeader

--- a/metadata/databases/default/tables/public_referendums.yaml
+++ b/metadata/databases/default/tables/public_referendums.yaml
@@ -69,6 +69,7 @@ select_permissions:
     filter: {}
   role: centralLeader
 - permission:
+    allow_aggregations: true
     columns:
     - createdAt
     - description
@@ -83,6 +84,7 @@ select_permissions:
     filter: {}
   role: section
 - permission:
+    allow_aggregations: true
     columns:
     - createdAt
     - description

--- a/metadata/databases/default/tables/public_users.yaml
+++ b/metadata/databases/default/tables/public_users.yaml
@@ -35,7 +35,6 @@ insert_permissions:
     check: {}
     columns:
     - addressId
-    - eVoted
     - egn
     - email
     - family
@@ -45,7 +44,6 @@ insert_permissions:
     - role
     - secondRole
     - surname
-    - voted
     - votingSectionId
   role: central
 - permission:
@@ -53,7 +51,6 @@ insert_permissions:
     check: {}
     columns:
     - addressId
-    - eVoted
     - egn
     - email
     - family
@@ -63,7 +60,6 @@ insert_permissions:
     - role
     - secondRole
     - surname
-    - voted
     - votingSectionId
   role: centralLeader
 select_permissions:
@@ -72,7 +68,6 @@ select_permissions:
     columns:
     - addressId
     - createdAt
-    - eVoted
     - egn
     - email
     - family
@@ -83,7 +78,6 @@ select_permissions:
     - secondRole
     - surname
     - updatedAt
-    - voted
     - votingSectionId
     filter: {}
   role: central
@@ -92,7 +86,6 @@ select_permissions:
     columns:
     - addressId
     - createdAt
-    - eVoted
     - egn
     - email
     - family
@@ -103,7 +96,6 @@ select_permissions:
     - secondRole
     - surname
     - updatedAt
-    - voted
     - votingSectionId
     filter: {}
   role: centralLeader
@@ -112,7 +104,6 @@ select_permissions:
     columns:
     - addressId
     - createdAt
-    - eVoted
     - egn
     - email
     - family
@@ -123,7 +114,6 @@ select_permissions:
     - secondRole
     - surname
     - updatedAt
-    - voted
     - votingSectionId
     filter: {}
   role: section
@@ -132,7 +122,6 @@ select_permissions:
     columns:
     - addressId
     - createdAt
-    - eVoted
     - egn
     - email
     - family
@@ -143,7 +132,6 @@ select_permissions:
     - secondRole
     - surname
     - updatedAt
-    - voted
     - votingSectionId
     filter: {}
   role: sectionLeader
@@ -152,7 +140,6 @@ select_permissions:
     columns:
     - addressId
     - createdAt
-    - eVoted
     - egn
     - email
     - family
@@ -163,7 +150,6 @@ select_permissions:
     - secondRole
     - surname
     - updatedAt
-    - voted
     - votingSectionId
     filter:
       id:
@@ -174,7 +160,6 @@ update_permissions:
     check: {}
     columns:
     - addressId
-    - eVoted
     - egn
     - email
     - family
@@ -185,7 +170,6 @@ update_permissions:
     - role
     - secondRole
     - surname
-    - voted
     - votingSectionId
     filter: {}
   role: central
@@ -193,7 +177,6 @@ update_permissions:
     check: {}
     columns:
     - addressId
-    - eVoted
     - egn
     - email
     - family
@@ -204,7 +187,6 @@ update_permissions:
     - role
     - secondRole
     - surname
-    - voted
     - votingSectionId
     filter: {}
   role: centralLeader

--- a/metadata/databases/default/tables/public_users.yaml
+++ b/metadata/databases/default/tables/public_users.yaml
@@ -14,6 +14,21 @@ object_relationships:
 - name: voting_section
   using:
     foreign_key_constraint_on: votingSectionId
+array_relationships:
+- name: referendum_votes
+  using:
+    foreign_key_constraint_on:
+      column: userId
+      table:
+        name: referendum_votes
+        schema: public
+- name: votes
+  using:
+    foreign_key_constraint_on:
+      column: userId
+      table:
+        name: votes
+        schema: public
 insert_permissions:
 - permission:
     backend_only: false

--- a/migrations/default/1645363628866_alter_table_public_users_drop_column_voted/down.sql
+++ b/migrations/default/1645363628866_alter_table_public_users_drop_column_voted/down.sql
@@ -1,0 +1,3 @@
+alter table "public"."users" alter column "voted" set default false;
+alter table "public"."users" alter column "voted" drop not null;
+alter table "public"."users" add column "voted" bool;

--- a/migrations/default/1645363628866_alter_table_public_users_drop_column_voted/up.sql
+++ b/migrations/default/1645363628866_alter_table_public_users_drop_column_voted/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."users" drop column "voted" cascade;

--- a/migrations/default/1645363640669_alter_table_public_users_drop_column_eVoted/down.sql
+++ b/migrations/default/1645363640669_alter_table_public_users_drop_column_eVoted/down.sql
@@ -1,0 +1,3 @@
+alter table "public"."users" alter column "eVoted" set default false;
+alter table "public"."users" alter column "eVoted" drop not null;
+alter table "public"."users" add column "eVoted" bool;

--- a/migrations/default/1645363640669_alter_table_public_users_drop_column_eVoted/up.sql
+++ b/migrations/default/1645363640669_alter_table_public_users_drop_column_eVoted/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."users" drop column "eVoted" cascade;

--- a/src/app/auth/logged-user.interface.ts
+++ b/src/app/auth/logged-user.interface.ts
@@ -7,7 +7,5 @@ export interface LoggedUser {
   family: string;
   roleType: Role_Types;
   secondRoleType: Role_Types;
-  eVoted: boolean;
-  voted: boolean;
   votingSectionId: number;
 }

--- a/src/app/core/vixen/vixen.component.ts
+++ b/src/app/core/vixen/vixen.component.ts
@@ -46,7 +46,7 @@ export class VixenComponent implements OnDestroy {
     if (index === 0) {
       return user.roleType.value as Role_Types_Enum;
     } else if (index === 1) {
-      return user.secondRoleType.value as Role_Types_Enum;
+      return user?.secondRoleType.value as Role_Types_Enum;
     }
     return null;
   }

--- a/src/app/core/vixen/vixen.component.ts
+++ b/src/app/core/vixen/vixen.component.ts
@@ -43,12 +43,9 @@ export class VixenComponent implements OnDestroy {
   }
 
   getUSerRole(user: Users, index: number): Role_Types_Enum {
-    console.log(index);
     if (index === 0) {
-      console.log('q');
       return user.roleType.value as Role_Types_Enum;
     } else if (index === 1) {
-      console.log('l');
       return user.secondRoleType.value as Role_Types_Enum;
     }
     return null;

--- a/src/app/navigation/navigation.component.ts
+++ b/src/app/navigation/navigation.component.ts
@@ -130,59 +130,73 @@ export class NavigationComponent
     this.menus = [];
     switch (role) {
       case Role_Types_Enum.Admin:
+        this.addMenu('users');
+        this.addMenu('settlements');
+        this.addMenu('voting-sections');
+        this.addMenu('votings-list');
+        this.addMenu('referendums-list');
+        break;
+
       case Role_Types_Enum.CentralLeader:
       case Role_Types_Enum.Central:
+        this.addMenu('users');
+        this.addMenu('settlements');
+        this.addMenu('voting-sections');
+        this.addMenu('votings-list');
+        this.addMenu('referendums-list');
+
+        // if (environment.production === false) {
+        //   // in prod this menu should not be visible. Vote only with the role "USER"
+        //   this.addMenu('votings');
+        // }
+        this.addMenu('counting');
+        break;
       case Role_Types_Enum.SectionLeader:
+        this.addMenu('users');
+        // this.addMenu('settlements');
+        //  this.addMenu('voting-sections');
+        this.addMenu('votings-list');
+        this.addMenu('referendums-list');
+        break;
       case Role_Types_Enum.Section:
+        this.addMenu('users');
+        //  this.addMenu('settlements');
+        this.addMenu('votings-list');
+        this.addMenu('referendums-list');
+        break;
+      case Role_Types_Enum.User:
+        this.addMenu('votings');
+        break;
+      default:
+        // ?? Who is here
+        this.authService.clearAll();
+        break;
+    }
+
+    if (environment.production === false) {
+      // in prod this menu should not be visible. Vote only with the role "USER"
+      this.addMenu('votings');
+    }
+  }
+  addMenu(key: string) {
+    switch (key) {
+      case 'users':
         this.menus.push({
           route: 'users',
           label: 'Гласоподаватели',
           matIcon: 'groups',
           badgeSubject: undefined,
         });
+        break;
+      case 'settlements':
         this.menus.push({
           route: 'settlements',
           label: 'Населени места',
           matIcon: 'location_city',
           badgeSubject: undefined,
         });
-        this.menus.push({
-          route: 'voting-sections',
-          label: 'Секции',
-          matIcon: 'how_to_vote',
-          badgeSubject: undefined,
-        });
-
-        this.menus.push({
-          route: 'votings/votings-list',
-          label: 'Избори',
-          matIcon: 'list',
-          badgeSubject: undefined,
-        });
-        this.menus.push({
-          route: 'votings/referendums-list',
-          label: 'Референдуми',
-          matIcon: 'list',
-          badgeSubject: undefined,
-        });
-        if (environment.production === false) {
-          // in prod this menu should not be visible. Vote only with the role "USER"
-          this.menus.push({
-            route: 'votings/dashboard',
-            label: 'Гласуване',
-            matIcon: 'front_hand',
-            badgeSubject: undefined,
-          });
-        }
-
-        this.menus.push({
-          route: 'countings/dashboard',
-          label: 'Преброяване',
-          matIcon: 'functions',
-          badgeSubject: undefined,
-        });
         break;
-      case Role_Types_Enum.User:
+      case 'votings':
         this.menus.push({
           route: 'votings/dashboard',
           label: 'Гласуване',
@@ -190,9 +204,42 @@ export class NavigationComponent
           badgeSubject: undefined,
         });
         break;
+
+      case 'voting-sections':
+        this.menus.push({
+          route: 'voting-sections',
+          label: 'Секции',
+          matIcon: 'how_to_vote',
+          badgeSubject: undefined,
+        });
+        break;
+      case 'votings-list':
+        this.menus.push({
+          route: 'votings/votings-list',
+          label: 'Избори',
+          matIcon: 'list',
+          badgeSubject: undefined,
+        });
+        break;
+      case 'referendums-list':
+        this.menus.push({
+          route: 'votings/referendums-list',
+          label: 'Референдуми',
+          matIcon: 'list',
+          badgeSubject: undefined,
+        });
+        break;
+
+      case 'counting':
+        this.menus.push({
+          route: 'countings/dashboard',
+          label: 'Преброяване',
+          matIcon: 'functions',
+          badgeSubject: undefined,
+        });
+        break;
+
       default:
-        // ?? Who is here
-        this.authService.clearAll();
         break;
     }
   }

--- a/src/app/users/election.class.ts
+++ b/src/app/users/election.class.ts
@@ -1,0 +1,8 @@
+export class Election {
+  type: string;
+  id: number;
+  name: string;
+  description: string;
+  startDate?: any;
+  finishedAt?: any;
+}

--- a/src/app/users/users-service.ts
+++ b/src/app/users/users-service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { FetchResult } from '@apollo/client';
+import { ApolloQueryResult, FetchResult } from '@apollo/client';
 import { QueryRef } from 'apollo-angular';
 import { Observable } from 'rxjs';
 import {
@@ -10,6 +10,8 @@ import {
   CreateUserGQL,
   CreateUserMutation,
   DistributeUsersGQL,
+  GetUserByIdGQL,
+  GetUserByIdQuery,
   GetUsersGQL,
   GetUsersQuery,
   UpdateUserGQL,
@@ -28,7 +30,8 @@ export class UsersService {
     private getUsersGQL: GetUsersGQL,
     private bulkInsertUsersGQL: BulkInsertUsersGQL,
     private countUndistributedToVotingSectionsGQL: CountUndistributedToVotingSectionsGQL,
-    private distributeUsersGQL: DistributeUsersGQL
+    private distributeUsersGQL: DistributeUsersGQL,
+    private getUserByIdGQL: GetUserByIdGQL
   ) {}
 
   createUser(
@@ -76,6 +79,10 @@ export class UsersService {
         pollInterval: 60 * 1000,
       }
     );
+  }
+
+  getUserById(id: number): Observable<ApolloQueryResult<GetUserByIdQuery>> {
+    return this.getUserByIdGQL.fetch({ id });
   }
 
   updateUser(addressSet: Addresses_Set_Input, userSet: Users_Set_Input) {

--- a/src/app/users/users-table/custom-user.class.ts
+++ b/src/app/users/users-table/custom-user.class.ts
@@ -1,0 +1,40 @@
+import {
+  Addresses,
+  Referendum_Votes,
+  Referendum_Votes_Aggregate,
+  Role_Types,
+  Role_Types_Enum,
+  Users,
+  Votes,
+  Votes_Aggregate,
+  Voting_Section,
+} from 'src/generated/graphql';
+
+export class CustomUser implements Users {
+  tempVoted: boolean;
+  __typename?: 'users';
+  address: Addresses;
+  addressId: number;
+  createdAt: any;
+  eVoted: boolean;
+  egn: string;
+  email?: string;
+  family: string;
+  id: number;
+  name: string;
+  password?: string;
+  pin?: string;
+  referendum_votes: Referendum_Votes[];
+  referendum_votes_aggregate: Referendum_Votes_Aggregate;
+  role: Role_Types_Enum;
+  roleType: Role_Types;
+  secondRole?: Role_Types_Enum;
+  secondRoleType?: Role_Types;
+  surname: string;
+  updatedAt: any;
+  voted: boolean;
+  votes: Votes[];
+  votes_aggregate: Votes_Aggregate;
+  votingSectionId?: number;
+  voting_section?: Voting_Section;
+}

--- a/src/app/users/users-table/users-table.component.html
+++ b/src/app/users/users-table/users-table.component.html
@@ -139,22 +139,6 @@
       <th mat-header-cell *matHeaderCellDef>ел. поща</th>
       <td mat-cell *matCellDef="let row">{{ row.email }}</td>
     </ng-container>
-    <!-- voted Column -->
-    <!-- <ng-container matColumnDef="voted">
-      <th mat-header-cell *matHeaderCellDef>гласувал</th>
-      <td mat-cell *matCellDef="let row">
-       
-        {{ row.voted }}
-      </td>
-    </ng-container> -->
-    <!-- eVoted Column -->
-    <!-- <ng-container matColumnDef="eVoted">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header>е-гласувал</th>
-      <td mat-cell *matCellDef="let row">
-       
-        {{ row.eVoted }}
-      </td>
-    </ng-container> -->
 
     <ng-container matColumnDef="tempVoted">
       <th mat-header-cell *matHeaderCellDef>гласувал</th>

--- a/src/app/users/users-table/users-table.component.html
+++ b/src/app/users/users-table/users-table.component.html
@@ -13,6 +13,19 @@
     ><mat-hint>търсене по ЕГН</mat-hint>
   </mat-form-field>
 
+  <mat-form-field appearance="fill" class="espi-egn-search">
+    <mat-label>Тип избор</mat-label>
+    <!--   [(value)]="selectedElection" -->
+    <mat-select #actionTypesSelect formControlName="voting">
+      <div (mouseleave)="actionTypesSelect.close()">
+        <mat-option *ngFor="let referendum of elections" [value]="referendum">{{
+          referendum.name
+        }}</mat-option>
+      </div>
+    </mat-select>
+    <mat-hint align="end">Филтриране по действия ^</mat-hint>
+  </mat-form-field>
+
   <div
     *ngIf="canUserSeeThis() | async"
     style="display: flex; justify-content: flex-end"
@@ -72,7 +85,7 @@
   <table mat-table class="full-width-table" matSort aria-label="Elements">
     <!-- Id Column -->
     <ng-container matColumnDef="id">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header>Id</th>
+      <th mat-header-cell *matHeaderCellDef>Id</th>
       <td mat-cell *matCellDef="let row">{{ row.id }}</td>
     </ng-container>
 
@@ -83,19 +96,19 @@
     </ng-container>
 
     <!-- createdAt Column -->
-    <ng-container matColumnDef="createdAt">
+    <!-- <ng-container matColumnDef="createdAt">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>създаден на</th>
       <td mat-cell *matCellDef="let row">
         {{ row.createdAt | date: "d.MM.YYYY HH:mm:ss" }}
       </td>
-    </ng-container>
+    </ng-container> -->
     <!-- updatedAt Column -->
-    <ng-container matColumnDef="updatedAt">
+    <!-- <ng-container matColumnDef="updatedAt">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>промемен на</th>
       <td mat-cell *matCellDef="let row">
         {{ row.updatedAt | date: "d.MM.YYYY HH:mm:ss" }}
       </td>
-    </ng-container>
+    </ng-container> -->
     <!-- name Column -->
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>име</th>
@@ -123,32 +136,35 @@
     </ng-container>
     <!-- email Column -->
     <ng-container matColumnDef="email">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header>ел. поща</th>
+      <th mat-header-cell *matHeaderCellDef>ел. поща</th>
       <td mat-cell *matCellDef="let row">{{ row.email }}</td>
     </ng-container>
     <!-- voted Column -->
-    <ng-container matColumnDef="voted">
-      <th mat-header-cell *matHeaderCellDef mat-sort-header>гласувал</th>
+    <!-- <ng-container matColumnDef="voted">
+      <th mat-header-cell *matHeaderCellDef>гласувал</th>
       <td mat-cell *matCellDef="let row">
-        <!-- <mat-checkbox
-          color="accent"
-          [checked]="row.voted"
-          [disabled]="true"
-        ></mat-checkbox> -->
+       
         {{ row.voted }}
       </td>
-    </ng-container>
+    </ng-container> -->
     <!-- eVoted Column -->
-    <ng-container matColumnDef="eVoted">
+    <!-- <ng-container matColumnDef="eVoted">
       <th mat-header-cell *matHeaderCellDef mat-sort-header>е-гласувал</th>
       <td mat-cell *matCellDef="let row">
-        <!--  (change)="onVatStatementChange($event)" -->
-        <!-- <mat-checkbox
-          color="accent"
-          [checked]="row.eVoted"
-          [disabled]="true"
-        ></mat-checkbox> -->
+       
         {{ row.eVoted }}
+      </td>
+    </ng-container> -->
+
+    <ng-container matColumnDef="tempVoted">
+      <th mat-header-cell *matHeaderCellDef>гласувал</th>
+      <td mat-cell *matCellDef="let row">
+        <div *ngIf="row.tempVoted === true">
+          <mat-icon style="color: green; font-size: 40px">check</mat-icon>
+        </div>
+        <div *ngIf="row.tempVoted === false">
+          <mat-icon style="color: red; font-size: 40px">clear</mat-icon>
+        </div>
       </td>
     </ng-container>
 

--- a/src/app/users/users.graphql
+++ b/src/app/users/users.graphql
@@ -21,6 +21,12 @@ mutation CreateUser($input: users_insert_input!) {
   }
 }
 
+query GetUserById($id: Int!) {
+  users_by_pk(id: $id) {
+    ...UserFields
+  }
+}
+
 mutation UpdateUser(
   $addrId: Int!
   $addressSet: addresses_set_input!
@@ -56,8 +62,6 @@ fragment UserFields on users {
   pin
   # password
   addressId
-  voted
-  eVoted
   votingSectionId
   roleType {
     value

--- a/src/app/users/users.graphql
+++ b/src/app/users/users.graphql
@@ -74,6 +74,15 @@ fragment UserFields on users {
       ...SettlementFileds
     }
   }
+  referendum_votes {
+    vote
+    eVote
+    referendum_question {
+      referendum {
+        id
+      }
+    }
+  }
 }
 # distributor
 

--- a/src/app/votings/referendum/custom-referendum.class.ts
+++ b/src/app/votings/referendum/custom-referendum.class.ts
@@ -1,4 +1,9 @@
-import { Referendum_Questions, Referendum_Votes, Referendum_Votes_Aggregate } from 'src/generated/graphql';
+import {
+  Referendums,
+  Referendum_Questions,
+  Referendum_Votes,
+  Referendum_Votes_Aggregate,
+} from 'src/generated/graphql';
 
 export class CustomReferendumQuestion implements Referendum_Questions {
   questionNumber: number; // !NOTE - zero is the last page
@@ -13,4 +18,5 @@ export class CustomReferendumQuestion implements Referendum_Questions {
   updatedAt: any;
   referendum_votes: Referendum_Votes[];
   referendum_votes_aggregate: Referendum_Votes_Aggregate;
+  referendum: Referendums;
 }

--- a/src/app/votings/referendums-table/referendums-table.component.html
+++ b/src/app/votings/referendums-table/referendums-table.component.html
@@ -11,6 +11,7 @@
 
 <div style="display: flex; justify-content: flex-end">
   <button
+    *ngIf="canUnlock()"
     mat-raised-button
     style="margin: 10px"
     color="accent"

--- a/src/app/votings/votings-dashboard/votings-dashboard.component.html
+++ b/src/app/votings/votings-dashboard/votings-dashboard.component.html
@@ -3,44 +3,45 @@
     mode="indeterminate"
     *ngIf="loading$ | async"
   ></mat-progress-bar>
-  <div *ngIf="isVoted" >
+  <!-- <div>
     <mat-card>
       <div class="header">
         <mat-card-title>Вашият глас вече е отчетен!</mat-card-title>
       </div>
-    
-      <mat-card-content>
-        <div class="image">
-          
-        </div>
-        <h3>Вие успешно сте гласувал на място и вашият глас е отчетен.</h3>
 
+      <mat-card-content>
+        <div class="image"></div>
+        <h3>Вие успешно сте гласувал на място и вашият глас е отчетен.</h3>
       </mat-card-content>
       <mat-card-footer
         >Проверете имейл адреса си за верификационно съобщение!</mat-card-footer
       >
     </mat-card>
-  </div>
+  </div> -->
   <div *ngIf="(loading$ | async) === false">
-    <h1 *ngIf="!isVoted && (cards | async)?.length > 0" class="mat-h1">Избори</h1>
+    <h1 *ngIf="(cards | async)?.length > 0" class="mat-h1">Избори</h1>
     <h1
-      *ngIf="!isVoted && (cards | async)?.length === 0 && (loading$ | async) === false"
+      *ngIf="(cards | async)?.length === 0 && (loading$ | async) === false"
       class="mat-h1"
     >
       В момента не се провеждат избори.
     </h1>
   </div>
-  <mat-grid-list *ngIf="!isVoted" cols="2" rowHeight="350px">
+  <mat-grid-list cols="2" rowHeight="350px">
     <mat-grid-tile
       *ngFor="let card of cards | async"
       [colspan]="card.cols"
       [rowspan]="card.rows"
     >
-      <mat-card class="dashboard-card">
+      <mat-card
+        class="dashboard-card"
+        [ngClass]="card.alreadyVoted ? 'voted' : 'non-voted'"
+      >
         <mat-card-header>
           <mat-card-title>
             {{ card.title }}
             <button
+              *ngIf="card.alreadyVoted === false"
               mat-icon-button
               class="more-button"
               [matMenuTriggerFor]="menu"

--- a/src/app/votings/votings-dashboard/votings-dashboard.component.scss
+++ b/src/app/votings/votings-dashboard/votings-dashboard.component.scss
@@ -19,3 +19,11 @@
 .dashboard-card-content {
   text-align: center;
 }
+
+.voted {
+  background: rgb(240, 255, 241);
+}
+
+.non-voted {
+  background: rgb(255, 249, 222);
+}

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -6141,7 +6141,6 @@ export type Users = {
   address: Addresses;
   addressId: Scalars['Int'];
   createdAt: Scalars['timestamptz'];
-  eVoted: Scalars['Boolean'];
   egn: Scalars['String'];
   email?: Maybe<Scalars['String']>;
   family: Scalars['String'];
@@ -6161,7 +6160,6 @@ export type Users = {
   secondRoleType?: Maybe<Role_Types>;
   surname: Scalars['String'];
   updatedAt: Scalars['timestamptz'];
-  voted: Scalars['Boolean'];
   /** fetch data from the table: "votes" */
   votes: Array<Votes>;
   /** fetch aggregated fields from the table: "votes" */
@@ -6257,7 +6255,6 @@ export type Users_Bool_Exp = {
   address?: Maybe<Addresses_Bool_Exp>;
   addressId?: Maybe<Int_Comparison_Exp>;
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
-  eVoted?: Maybe<Boolean_Comparison_Exp>;
   egn?: Maybe<String_Comparison_Exp>;
   email?: Maybe<String_Comparison_Exp>;
   family?: Maybe<String_Comparison_Exp>;
@@ -6272,7 +6269,6 @@ export type Users_Bool_Exp = {
   secondRoleType?: Maybe<Role_Types_Bool_Exp>;
   surname?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
-  voted?: Maybe<Boolean_Comparison_Exp>;
   votes?: Maybe<Votes_Bool_Exp>;
   votingSectionId?: Maybe<Int_Comparison_Exp>;
   voting_section?: Maybe<Voting_Section_Bool_Exp>;
@@ -6298,7 +6294,6 @@ export type Users_Insert_Input = {
   address?: Maybe<Addresses_Obj_Rel_Insert_Input>;
   addressId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  eVoted?: Maybe<Scalars['Boolean']>;
   egn?: Maybe<Scalars['String']>;
   email?: Maybe<Scalars['String']>;
   family?: Maybe<Scalars['String']>;
@@ -6313,7 +6308,6 @@ export type Users_Insert_Input = {
   secondRoleType?: Maybe<Role_Types_Obj_Rel_Insert_Input>;
   surname?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
-  voted?: Maybe<Scalars['Boolean']>;
   votes?: Maybe<Votes_Arr_Rel_Insert_Input>;
   votingSectionId?: Maybe<Scalars['Int']>;
   voting_section?: Maybe<Voting_Section_Obj_Rel_Insert_Input>;
@@ -6374,7 +6368,6 @@ export type Users_Order_By = {
   address?: Maybe<Addresses_Order_By>;
   addressId?: Maybe<Order_By>;
   createdAt?: Maybe<Order_By>;
-  eVoted?: Maybe<Order_By>;
   egn?: Maybe<Order_By>;
   email?: Maybe<Order_By>;
   family?: Maybe<Order_By>;
@@ -6389,7 +6382,6 @@ export type Users_Order_By = {
   secondRoleType?: Maybe<Role_Types_Order_By>;
   surname?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
-  voted?: Maybe<Order_By>;
   votes_aggregate?: Maybe<Votes_Aggregate_Order_By>;
   votingSectionId?: Maybe<Order_By>;
   voting_section?: Maybe<Voting_Section_Order_By>;
@@ -6406,8 +6398,6 @@ export enum Users_Select_Column {
   AddressId = 'addressId',
   /** column name */
   CreatedAt = 'createdAt',
-  /** column name */
-  EVoted = 'eVoted',
   /** column name */
   Egn = 'egn',
   /** column name */
@@ -6431,8 +6421,6 @@ export enum Users_Select_Column {
   /** column name */
   UpdatedAt = 'updatedAt',
   /** column name */
-  Voted = 'voted',
-  /** column name */
   VotingSectionId = 'votingSectionId'
 }
 
@@ -6440,7 +6428,6 @@ export enum Users_Select_Column {
 export type Users_Set_Input = {
   addressId?: Maybe<Scalars['Int']>;
   createdAt?: Maybe<Scalars['timestamptz']>;
-  eVoted?: Maybe<Scalars['Boolean']>;
   egn?: Maybe<Scalars['String']>;
   email?: Maybe<Scalars['String']>;
   family?: Maybe<Scalars['String']>;
@@ -6452,7 +6439,6 @@ export type Users_Set_Input = {
   secondRole?: Maybe<Role_Types_Enum>;
   surname?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
-  voted?: Maybe<Scalars['Boolean']>;
   votingSectionId?: Maybe<Scalars['Int']>;
 };
 
@@ -6495,8 +6481,6 @@ export enum Users_Update_Column {
   /** column name */
   CreatedAt = 'createdAt',
   /** column name */
-  EVoted = 'eVoted',
-  /** column name */
   Egn = 'egn',
   /** column name */
   Email = 'email',
@@ -6518,8 +6502,6 @@ export enum Users_Update_Column {
   Surname = 'surname',
   /** column name */
   UpdatedAt = 'updatedAt',
-  /** column name */
-  Voted = 'voted',
   /** column name */
   VotingSectionId = 'votingSectionId'
 }
@@ -8055,6 +8037,19 @@ export type CreateUserMutation = (
   )> }
 );
 
+export type GetUserByIdQueryVariables = Exact<{
+  id: Scalars['Int'];
+}>;
+
+
+export type GetUserByIdQuery = (
+  { __typename?: 'query_root' }
+  & { users_by_pk?: Maybe<(
+    { __typename?: 'users' }
+    & UserFieldsFragment
+  )> }
+);
+
 export type UpdateUserMutationVariables = Exact<{
   addrId: Scalars['Int'];
   addressSet: Addresses_Set_Input;
@@ -8089,7 +8084,7 @@ export type BulkInsertUsersMutation = (
 
 export type UserFieldsFragment = (
   { __typename?: 'users' }
-  & Pick<Users, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'surname' | 'family' | 'egn' | 'email' | 'pin' | 'addressId' | 'voted' | 'eVoted' | 'votingSectionId'>
+  & Pick<Users, 'id' | 'createdAt' | 'updatedAt' | 'name' | 'surname' | 'family' | 'egn' | 'email' | 'pin' | 'addressId' | 'votingSectionId'>
   & { roleType: (
     { __typename?: 'role_types' }
     & Pick<Role_Types, 'value' | 'description'>
@@ -8382,8 +8377,6 @@ export const UserFieldsFragmentDoc = gql`
   email
   pin
   addressId
-  voted
-  eVoted
   votingSectionId
   roleType {
     value
@@ -8687,6 +8680,24 @@ export const CreateUserDocument = gql`
   })
   export class CreateUserGQL extends Apollo.Mutation<CreateUserMutation, CreateUserMutationVariables> {
     document = CreateUserDocument;
+    
+    constructor(apollo: Apollo.Apollo) {
+      super(apollo);
+    }
+  }
+export const GetUserByIdDocument = gql`
+    query GetUserById($id: Int!) {
+  users_by_pk(id: $id) {
+    ...UserFields
+  }
+}
+    ${UserFieldsFragmentDoc}`;
+
+  @Injectable({
+    providedIn: 'root'
+  })
+  export class GetUserByIdGQL extends Apollo.Query<GetUserByIdQuery, GetUserByIdQueryVariables> {
+    document = GetUserByIdDocument;
     
     constructor(apollo: Apollo.Apollo) {
       super(apollo);

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -3255,7 +3255,7 @@ export type Query_Root = {
   referendum_questions_by_pk?: Maybe<Referendum_Questions>;
   /** fetch data from the table: "referendum_votes" */
   referendum_votes: Array<Referendum_Votes>;
-  /** fetch aggregated fields from the table: "referendum_votes" */
+  /** An aggregate relationship */
   referendum_votes_aggregate: Referendum_Votes_Aggregate;
   /** fetch data from the table: "referendum_votes" using primary key columns */
   referendum_votes_by_pk?: Maybe<Referendum_Votes>;
@@ -3271,7 +3271,7 @@ export type Query_Root = {
   role_types_aggregate: Role_Types_Aggregate;
   /** fetch data from the table: "role_types" using primary key columns */
   role_types_by_pk?: Maybe<Role_Types>;
-  /** fetch data from the table: "settlements" */
+  /** An array relationship */
   settlements: Array<Settlements>;
   /** An aggregate relationship */
   settlements_aggregate: Settlements_Aggregate;
@@ -3998,10 +3998,12 @@ export type Referendum_Questions = {
   createdAt: Scalars['timestamptz'];
   id: Scalars['Int'];
   question: Scalars['String'];
+  /** An object relationship */
+  referendum: Referendums;
   referendumId: Scalars['Int'];
   /** fetch data from the table: "referendum_votes" */
   referendum_votes: Array<Referendum_Votes>;
-  /** fetch aggregated fields from the table: "referendum_votes" */
+  /** An aggregate relationship */
   referendum_votes_aggregate: Referendum_Votes_Aggregate;
   updatedAt: Scalars['timestamptz'];
 };
@@ -4099,6 +4101,7 @@ export type Referendum_Questions_Bool_Exp = {
   createdAt?: Maybe<Timestamptz_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   question?: Maybe<String_Comparison_Exp>;
+  referendum?: Maybe<Referendums_Bool_Exp>;
   referendumId?: Maybe<Int_Comparison_Exp>;
   referendum_votes?: Maybe<Referendum_Votes_Bool_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
@@ -4121,6 +4124,7 @@ export type Referendum_Questions_Insert_Input = {
   createdAt?: Maybe<Scalars['timestamptz']>;
   id?: Maybe<Scalars['Int']>;
   question?: Maybe<Scalars['String']>;
+  referendum?: Maybe<Referendums_Obj_Rel_Insert_Input>;
   referendumId?: Maybe<Scalars['Int']>;
   referendum_votes?: Maybe<Referendum_Votes_Arr_Rel_Insert_Input>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
@@ -4173,6 +4177,13 @@ export type Referendum_Questions_Mutation_Response = {
   returning: Array<Referendum_Questions>;
 };
 
+/** input type for inserting object relation for remote table "referendum_questions" */
+export type Referendum_Questions_Obj_Rel_Insert_Input = {
+  data: Referendum_Questions_Insert_Input;
+  /** on conflict condition */
+  on_conflict?: Maybe<Referendum_Questions_On_Conflict>;
+};
+
 /** on conflict condition type for table "referendum_questions" */
 export type Referendum_Questions_On_Conflict = {
   constraint: Referendum_Questions_Constraint;
@@ -4185,6 +4196,7 @@ export type Referendum_Questions_Order_By = {
   createdAt?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   question?: Maybe<Order_By>;
+  referendum?: Maybe<Referendums_Order_By>;
   referendumId?: Maybe<Order_By>;
   referendum_votes_aggregate?: Maybe<Referendum_Votes_Aggregate_Order_By>;
   updatedAt?: Maybe<Order_By>;
@@ -4330,6 +4342,8 @@ export type Referendum_Votes = {
   eVote?: Maybe<Scalars['Boolean']>;
   id: Scalars['Int'];
   questionId: Scalars['Int'];
+  /** An object relationship */
+  referendum_question: Referendum_Questions;
   sectionId?: Maybe<Scalars['Int']>;
   userId: Scalars['Int'];
   vote?: Maybe<Scalars['Boolean']>;
@@ -4413,6 +4427,7 @@ export type Referendum_Votes_Bool_Exp = {
   eVote?: Maybe<Boolean_Comparison_Exp>;
   id?: Maybe<Int_Comparison_Exp>;
   questionId?: Maybe<Int_Comparison_Exp>;
+  referendum_question?: Maybe<Referendum_Questions_Bool_Exp>;
   sectionId?: Maybe<Int_Comparison_Exp>;
   userId?: Maybe<Int_Comparison_Exp>;
   vote?: Maybe<Boolean_Comparison_Exp>;
@@ -4438,6 +4453,7 @@ export type Referendum_Votes_Insert_Input = {
   eVote?: Maybe<Scalars['Boolean']>;
   id?: Maybe<Scalars['Int']>;
   questionId?: Maybe<Scalars['Int']>;
+  referendum_question?: Maybe<Referendum_Questions_Obj_Rel_Insert_Input>;
   sectionId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
   vote?: Maybe<Scalars['Boolean']>;
@@ -4503,6 +4519,7 @@ export type Referendum_Votes_Order_By = {
   eVote?: Maybe<Order_By>;
   id?: Maybe<Order_By>;
   questionId?: Maybe<Order_By>;
+  referendum_question?: Maybe<Referendum_Questions_Order_By>;
   sectionId?: Maybe<Order_By>;
   userId?: Maybe<Order_By>;
   vote?: Maybe<Order_By>;
@@ -4843,6 +4860,13 @@ export type Referendums_Mutation_Response = {
   returning: Array<Referendums>;
 };
 
+/** input type for inserting object relation for remote table "referendums" */
+export type Referendums_Obj_Rel_Insert_Input = {
+  data: Referendums_Insert_Input;
+  /** on conflict condition */
+  on_conflict?: Maybe<Referendums_On_Conflict>;
+};
+
 /** on conflict condition type for table "referendums" */
 export type Referendums_On_Conflict = {
   constraint: Referendums_Constraint;
@@ -5135,7 +5159,7 @@ export type Settlements = {
   parentId?: Maybe<Scalars['Int']>;
   /** An object relationship */
   parentSettlement?: Maybe<Settlements>;
-  /** fetch data from the table: "settlements" */
+  /** An array relationship */
   settlements: Array<Settlements>;
   /** An aggregate relationship */
   settlements_aggregate: Settlements_Aggregate;
@@ -5524,7 +5548,7 @@ export type Subscription_Root = {
   referendum_questions_by_pk?: Maybe<Referendum_Questions>;
   /** fetch data from the table: "referendum_votes" */
   referendum_votes: Array<Referendum_Votes>;
-  /** fetch aggregated fields from the table: "referendum_votes" */
+  /** An aggregate relationship */
   referendum_votes_aggregate: Referendum_Votes_Aggregate;
   /** fetch data from the table: "referendum_votes" using primary key columns */
   referendum_votes_by_pk?: Maybe<Referendum_Votes>;
@@ -5540,7 +5564,7 @@ export type Subscription_Root = {
   role_types_aggregate: Role_Types_Aggregate;
   /** fetch data from the table: "role_types" using primary key columns */
   role_types_by_pk?: Maybe<Role_Types>;
-  /** fetch data from the table: "settlements" */
+  /** An array relationship */
   settlements: Array<Settlements>;
   /** An aggregate relationship */
   settlements_aggregate: Settlements_Aggregate;
@@ -6125,6 +6149,10 @@ export type Users = {
   name: Scalars['String'];
   password?: Maybe<Scalars['String']>;
   pin?: Maybe<Scalars['String']>;
+  /** fetch data from the table: "referendum_votes" */
+  referendum_votes: Array<Referendum_Votes>;
+  /** An aggregate relationship */
+  referendum_votes_aggregate: Referendum_Votes_Aggregate;
   role: Role_Types_Enum;
   /** An object relationship */
   roleType: Role_Types;
@@ -6134,7 +6162,53 @@ export type Users = {
   surname: Scalars['String'];
   updatedAt: Scalars['timestamptz'];
   voted: Scalars['Boolean'];
+  /** fetch data from the table: "votes" */
+  votes: Array<Votes>;
+  /** fetch aggregated fields from the table: "votes" */
+  votes_aggregate: Votes_Aggregate;
   votingSectionId?: Maybe<Scalars['Int']>;
+  /** An object relationship */
+  voting_section?: Maybe<Voting_Section>;
+};
+
+
+/** columns and relationships of "users" */
+export type UsersReferendum_VotesArgs = {
+  distinct_on?: Maybe<Array<Referendum_Votes_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Referendum_Votes_Order_By>>;
+  where?: Maybe<Referendum_Votes_Bool_Exp>;
+};
+
+
+/** columns and relationships of "users" */
+export type UsersReferendum_Votes_AggregateArgs = {
+  distinct_on?: Maybe<Array<Referendum_Votes_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Referendum_Votes_Order_By>>;
+  where?: Maybe<Referendum_Votes_Bool_Exp>;
+};
+
+
+/** columns and relationships of "users" */
+export type UsersVotesArgs = {
+  distinct_on?: Maybe<Array<Votes_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Votes_Order_By>>;
+  where?: Maybe<Votes_Bool_Exp>;
+};
+
+
+/** columns and relationships of "users" */
+export type UsersVotes_AggregateArgs = {
+  distinct_on?: Maybe<Array<Votes_Select_Column>>;
+  limit?: Maybe<Scalars['Int']>;
+  offset?: Maybe<Scalars['Int']>;
+  order_by?: Maybe<Array<Votes_Order_By>>;
+  where?: Maybe<Votes_Bool_Exp>;
 };
 
 /** aggregated selection of "users" */
@@ -6191,6 +6265,7 @@ export type Users_Bool_Exp = {
   name?: Maybe<String_Comparison_Exp>;
   password?: Maybe<String_Comparison_Exp>;
   pin?: Maybe<String_Comparison_Exp>;
+  referendum_votes?: Maybe<Referendum_Votes_Bool_Exp>;
   role?: Maybe<Role_Types_Enum_Comparison_Exp>;
   roleType?: Maybe<Role_Types_Bool_Exp>;
   secondRole?: Maybe<Role_Types_Enum_Comparison_Exp>;
@@ -6198,7 +6273,9 @@ export type Users_Bool_Exp = {
   surname?: Maybe<String_Comparison_Exp>;
   updatedAt?: Maybe<Timestamptz_Comparison_Exp>;
   voted?: Maybe<Boolean_Comparison_Exp>;
+  votes?: Maybe<Votes_Bool_Exp>;
   votingSectionId?: Maybe<Int_Comparison_Exp>;
+  voting_section?: Maybe<Voting_Section_Bool_Exp>;
 };
 
 /** unique or primary key constraints on table "users" */
@@ -6229,6 +6306,7 @@ export type Users_Insert_Input = {
   name?: Maybe<Scalars['String']>;
   password?: Maybe<Scalars['String']>;
   pin?: Maybe<Scalars['String']>;
+  referendum_votes?: Maybe<Referendum_Votes_Arr_Rel_Insert_Input>;
   role?: Maybe<Role_Types_Enum>;
   roleType?: Maybe<Role_Types_Obj_Rel_Insert_Input>;
   secondRole?: Maybe<Role_Types_Enum>;
@@ -6236,7 +6314,9 @@ export type Users_Insert_Input = {
   surname?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['timestamptz']>;
   voted?: Maybe<Scalars['Boolean']>;
+  votes?: Maybe<Votes_Arr_Rel_Insert_Input>;
   votingSectionId?: Maybe<Scalars['Int']>;
+  voting_section?: Maybe<Voting_Section_Obj_Rel_Insert_Input>;
 };
 
 /** aggregate max on columns */
@@ -6302,6 +6382,7 @@ export type Users_Order_By = {
   name?: Maybe<Order_By>;
   password?: Maybe<Order_By>;
   pin?: Maybe<Order_By>;
+  referendum_votes_aggregate?: Maybe<Referendum_Votes_Aggregate_Order_By>;
   role?: Maybe<Order_By>;
   roleType?: Maybe<Role_Types_Order_By>;
   secondRole?: Maybe<Order_By>;
@@ -6309,7 +6390,9 @@ export type Users_Order_By = {
   surname?: Maybe<Order_By>;
   updatedAt?: Maybe<Order_By>;
   voted?: Maybe<Order_By>;
+  votes_aggregate?: Maybe<Votes_Aggregate_Order_By>;
   votingSectionId?: Maybe<Order_By>;
+  voting_section?: Maybe<Voting_Section_Order_By>;
 };
 
 /** primary key columns input for table: users */
@@ -6507,6 +6590,28 @@ export type Votes_Aggregate_FieldsCountArgs = {
   distinct?: Maybe<Scalars['Boolean']>;
 };
 
+/** order by aggregate values of table "votes" */
+export type Votes_Aggregate_Order_By = {
+  avg?: Maybe<Votes_Avg_Order_By>;
+  count?: Maybe<Order_By>;
+  max?: Maybe<Votes_Max_Order_By>;
+  min?: Maybe<Votes_Min_Order_By>;
+  stddev?: Maybe<Votes_Stddev_Order_By>;
+  stddev_pop?: Maybe<Votes_Stddev_Pop_Order_By>;
+  stddev_samp?: Maybe<Votes_Stddev_Samp_Order_By>;
+  sum?: Maybe<Votes_Sum_Order_By>;
+  var_pop?: Maybe<Votes_Var_Pop_Order_By>;
+  var_samp?: Maybe<Votes_Var_Samp_Order_By>;
+  variance?: Maybe<Votes_Variance_Order_By>;
+};
+
+/** input type for inserting array relation for remote table "votes" */
+export type Votes_Arr_Rel_Insert_Input = {
+  data: Array<Votes_Insert_Input>;
+  /** on conflict condition */
+  on_conflict?: Maybe<Votes_On_Conflict>;
+};
+
 /** aggregate avg on columns */
 export type Votes_Avg_Fields = {
   __typename?: 'votes_avg_fields';
@@ -6514,6 +6619,14 @@ export type Votes_Avg_Fields = {
   sectionId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
   votingId?: Maybe<Scalars['Float']>;
+};
+
+/** order by avg() on columns of table "votes" */
+export type Votes_Avg_Order_By = {
+  id?: Maybe<Order_By>;
+  sectionId?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
+  votingId?: Maybe<Order_By>;
 };
 
 /** Boolean expression to filter rows from the table "votes". All fields are combined with a logical 'AND'. */
@@ -6567,6 +6680,17 @@ export type Votes_Max_Fields = {
   votingId?: Maybe<Scalars['Int']>;
 };
 
+/** order by max() on columns of table "votes" */
+export type Votes_Max_Order_By = {
+  createdAt?: Maybe<Order_By>;
+  eVote?: Maybe<Order_By>;
+  id?: Maybe<Order_By>;
+  sectionId?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
+  vote?: Maybe<Order_By>;
+  votingId?: Maybe<Order_By>;
+};
+
 /** aggregate min on columns */
 export type Votes_Min_Fields = {
   __typename?: 'votes_min_fields';
@@ -6577,6 +6701,17 @@ export type Votes_Min_Fields = {
   userId?: Maybe<Scalars['Int']>;
   vote?: Maybe<Scalars['String']>;
   votingId?: Maybe<Scalars['Int']>;
+};
+
+/** order by min() on columns of table "votes" */
+export type Votes_Min_Order_By = {
+  createdAt?: Maybe<Order_By>;
+  eVote?: Maybe<Order_By>;
+  id?: Maybe<Order_By>;
+  sectionId?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
+  vote?: Maybe<Order_By>;
+  votingId?: Maybe<Order_By>;
 };
 
 /** response of any mutation on the table "votes" */
@@ -6649,6 +6784,14 @@ export type Votes_Stddev_Fields = {
   votingId?: Maybe<Scalars['Float']>;
 };
 
+/** order by stddev() on columns of table "votes" */
+export type Votes_Stddev_Order_By = {
+  id?: Maybe<Order_By>;
+  sectionId?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
+  votingId?: Maybe<Order_By>;
+};
+
 /** aggregate stddev_pop on columns */
 export type Votes_Stddev_Pop_Fields = {
   __typename?: 'votes_stddev_pop_fields';
@@ -6656,6 +6799,14 @@ export type Votes_Stddev_Pop_Fields = {
   sectionId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
   votingId?: Maybe<Scalars['Float']>;
+};
+
+/** order by stddev_pop() on columns of table "votes" */
+export type Votes_Stddev_Pop_Order_By = {
+  id?: Maybe<Order_By>;
+  sectionId?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
+  votingId?: Maybe<Order_By>;
 };
 
 /** aggregate stddev_samp on columns */
@@ -6667,6 +6818,14 @@ export type Votes_Stddev_Samp_Fields = {
   votingId?: Maybe<Scalars['Float']>;
 };
 
+/** order by stddev_samp() on columns of table "votes" */
+export type Votes_Stddev_Samp_Order_By = {
+  id?: Maybe<Order_By>;
+  sectionId?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
+  votingId?: Maybe<Order_By>;
+};
+
 /** aggregate sum on columns */
 export type Votes_Sum_Fields = {
   __typename?: 'votes_sum_fields';
@@ -6674,6 +6833,14 @@ export type Votes_Sum_Fields = {
   sectionId?: Maybe<Scalars['Int']>;
   userId?: Maybe<Scalars['Int']>;
   votingId?: Maybe<Scalars['Int']>;
+};
+
+/** order by sum() on columns of table "votes" */
+export type Votes_Sum_Order_By = {
+  id?: Maybe<Order_By>;
+  sectionId?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
+  votingId?: Maybe<Order_By>;
 };
 
 /** update columns of table "votes" */
@@ -6703,6 +6870,14 @@ export type Votes_Var_Pop_Fields = {
   votingId?: Maybe<Scalars['Float']>;
 };
 
+/** order by var_pop() on columns of table "votes" */
+export type Votes_Var_Pop_Order_By = {
+  id?: Maybe<Order_By>;
+  sectionId?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
+  votingId?: Maybe<Order_By>;
+};
+
 /** aggregate var_samp on columns */
 export type Votes_Var_Samp_Fields = {
   __typename?: 'votes_var_samp_fields';
@@ -6712,6 +6887,14 @@ export type Votes_Var_Samp_Fields = {
   votingId?: Maybe<Scalars['Float']>;
 };
 
+/** order by var_samp() on columns of table "votes" */
+export type Votes_Var_Samp_Order_By = {
+  id?: Maybe<Order_By>;
+  sectionId?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
+  votingId?: Maybe<Order_By>;
+};
+
 /** aggregate variance on columns */
 export type Votes_Variance_Fields = {
   __typename?: 'votes_variance_fields';
@@ -6719,6 +6902,14 @@ export type Votes_Variance_Fields = {
   sectionId?: Maybe<Scalars['Float']>;
   userId?: Maybe<Scalars['Float']>;
   votingId?: Maybe<Scalars['Float']>;
+};
+
+/** order by variance() on columns of table "votes" */
+export type Votes_Variance_Order_By = {
+  id?: Maybe<Order_By>;
+  sectionId?: Maybe<Order_By>;
+  userId?: Maybe<Order_By>;
+  votingId?: Maybe<Order_By>;
 };
 
 /** columns and relationships of "voting_section" */
@@ -6837,6 +7028,13 @@ export type Voting_Section_Mutation_Response = {
   affected_rows: Scalars['Int'];
   /** data from the rows affected by the mutation */
   returning: Array<Voting_Section>;
+};
+
+/** input type for inserting object relation for remote table "voting_section" */
+export type Voting_Section_Obj_Rel_Insert_Input = {
+  data: Voting_Section_Insert_Input;
+  /** on conflict condition */
+  on_conflict?: Maybe<Voting_Section_On_Conflict>;
 };
 
 /** on conflict condition type for table "voting_section" */
@@ -7905,7 +8103,17 @@ export type UserFieldsFragment = (
       & SettlementFiledsFragment
     ) }
     & AddressShortFragment
-  ) }
+  ), referendum_votes: Array<(
+    { __typename?: 'referendum_votes' }
+    & Pick<Referendum_Votes, 'vote' | 'eVote'>
+    & { referendum_question: (
+      { __typename?: 'referendum_questions' }
+      & { referendum: (
+        { __typename?: 'referendums' }
+        & Pick<Referendums, 'id'>
+      ) }
+    ) }
+  )> }
 );
 
 export type CountUndistributedToVotingSectionsQueryVariables = Exact<{ [key: string]: never; }>;
@@ -8189,6 +8397,15 @@ export const UserFieldsFragmentDoc = gql`
     ...AddressShort
     settlement {
       ...SettlementFileds
+    }
+  }
+  referendum_votes {
+    vote
+    eVote
+    referendum_question {
+      referendum {
+        id
+      }
     }
   }
 }


### PR DESCRIPTION
 Добавил съм клас във фронтенда(Election), който обеденява двата типа избори. 
 Това е така за да може при преглед на потребителите, да е възможно изобразяване на статуса на гласуване, и по-точно за какво е гласувал,
 ако има два избора(парламент и президент) и референдум едновременно.
 От `users` са изтрити колоните voted и eVoted, защото не е ясно за кой от текущите изборите се отнасят тези данни.